### PR TITLE
Install xmlrpc if the version of runtime ruby is 2.4.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ..gemspec
 gemspec
+
+if RUBY_VERSION >= '2.4.0'
+  gem 'xmlrpc'
+end


### PR DESCRIPTION
According to [the ticket on bugs.ruby-lang.org](https://bugs.ruby-lang.org/issues/12160), xmlrpc is going to be extracted from stdlib and be moved to bundled gem. 

Actually tests of this gem did not pass on ruby 2.4.0-dev. 
